### PR TITLE
Rename Meadow.Data.File to Meadow.Data.FileSet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ erl_crash.dump
 meadow-*.tar
 
 **/.elixir_ls/
+**/.vscode/

--- a/.iex.exs
+++ b/.iex.exs
@@ -1,0 +1,10 @@
+alias Meadow.Data.{
+  Repo,
+  Image,
+  Collection,
+  FileSet
+}
+
+import_if_available(Ecto.Query)
+
+import_if_available(Ecto.Changeset)

--- a/apps/meadow_data/lib/meadow_data/file_set.ex
+++ b/apps/meadow_data/lib/meadow_data/file_set.ex
@@ -1,4 +1,4 @@
-defmodule Meadow.Data.File do
+defmodule Meadow.Data.FileSet do
   use Ecto.Schema
   alias Meadow.Data.Image
 
@@ -6,7 +6,7 @@ defmodule Meadow.Data.File do
 
   @primary_key {:id, Ecto.ULID, autogenerate: true}
   @foreign_key_type Ecto.ULID
-  schema "files" do
+  schema "file_sets" do
     field(:original_filename, :string)
     field(:location, :string)
     timestamps()
@@ -14,8 +14,8 @@ defmodule Meadow.Data.File do
     belongs_to(:image, Image)
   end
 
-  def changeset(file, params) do
-    file
+  def changeset(file_set, params) do
+    file_set
     |> cast(params, [:original_filename, :string])
     |> validate_required([:original_filename, :string])
   end

--- a/apps/meadow_data/lib/meadow_data/image.ex
+++ b/apps/meadow_data/lib/meadow_data/image.ex
@@ -1,6 +1,6 @@
 defmodule Meadow.Data.Image do
   use Ecto.Schema
-  alias Meadow.Data.{Collection, File}
+  alias Meadow.Data.{Collection, FileSet}
 
   import Ecto.Changeset
 
@@ -13,10 +13,15 @@ defmodule Meadow.Data.Image do
     field(:keyword, {:array, :string})
     timestamps()
 
-    has_many(:files, File)
+    has_many(:file_sets, FileSet)
     many_to_many(:collections, Collection, join_through: "images_collections")
   end
 
+  @spec changeset(
+          {map(), map()}
+          | %{:__struct__ => atom() | %{__changeset__: map()}, optional(atom()) => any()},
+          :invalid | %{optional(:__struct__) => none(), optional(atom() | binary()) => any()}
+        ) :: Ecto.Changeset.t()
   def changeset(image, params) do
     image
     |> cast(params, [:title])

--- a/apps/meadow_data/priv/repo/dev_seeds.exs
+++ b/apps/meadow_data/priv/repo/dev_seeds.exs
@@ -1,5 +1,5 @@
 alias Meadow.Data.Repo
-alias Meadow.Data.{Collection, File, Image}
+alias Meadow.Data.{Collection, FileSet, Image}
 
 Repo.insert!(%Collection{
   title: "Collection One",
@@ -8,16 +8,16 @@ Repo.insert!(%Collection{
     %Image{
       title: "Great Image",
       keyword: ["great", "image"],
-      files: [
-        %File{
+      file_sets: [
+        %FileSet{
           original_filename: "So_What.txt",
           location: "https://library.northwestern.edu/1"
         },
-        %File{
+        %FileSet{
           original_filename: "So_What_Again.txt",
           location: "https://library.northwestern.edu/2"
         },
-        %File{
+        %FileSet{
           original_filename: "So_What_AGAIN.txt",
           location: "https://library.northwestern.edu/3"
         }
@@ -26,12 +26,12 @@ Repo.insert!(%Collection{
     %Image{
       title: "Bad Image",
       keyword: ["bad", "image"],
-      files: [
-        %File{
+      file_sets: [
+        %FileSet{
           original_filename: "So_What_now.txt",
           location: "https://library.northwestern.edu/4"
         },
-        %File{
+        %FileSet{
           original_filename: "So_What_Again_please.txt",
           location: "https://library.northwestern.edu/5"
         }

--- a/apps/meadow_data/priv/repo/migrations/20190416183745_add_files_table.exs
+++ b/apps/meadow_data/priv/repo/migrations/20190416183745_add_files_table.exs
@@ -1,8 +1,8 @@
-defmodule Meadow.Data.Repo.Migrations.AddFilesTable do
+defmodule Meadow.Data.Repo.Migrations.AddFileSetsTable do
   use Ecto.Migration
 
   def change do
-    create table(:files, primary_key: false) do
+    create table(:file_sets, primary_key: false) do
       add(:id, :binary_id, null: false, primary_key: true)
       add(:original_filename, :string)
       add(:location, :string)

--- a/apps/meadow_data/priv/repo/seeds.exs
+++ b/apps/meadow_data/priv/repo/seeds.exs
@@ -1,5 +1,5 @@
 alias Meadow.Data.Repo
-alias Meadow.Data.{Collection, File, Image}
+alias Meadow.Data.{Collection, FileSet, Image}
 
 Repo.insert!(%Collection{
   title: "Collection One",
@@ -8,16 +8,16 @@ Repo.insert!(%Collection{
     %Image{
       title: "Great Image",
       keyword: ["great", "image"],
-      files: [
-        %File{
+      file_sets: [
+        %FileSet{
           original_filename: "So_What.txt",
           location: "https://library.northwestern.edu/1"
         },
-        %File{
+        %FileSet{
           original_filename: "So_What_Again.txt",
           location: "https://library.northwestern.edu/2"
         },
-        %File{
+        %FileSet{
           original_filename: "So_What_AGAIN.txt",
           location: "https://library.northwestern.edu/3"
         }
@@ -26,12 +26,12 @@ Repo.insert!(%Collection{
     %Image{
       title: "Bad Image",
       keyword: ["bad", "image"],
-      files: [
-        %File{
+      file_sets: [
+        %FileSet{
           original_filename: "So_What_now.txt",
           location: "https://library.northwestern.edu/4"
         },
-        %File{
+        %FileSet{
           original_filename: "So_What_Again_please.txt",
           location: "https://library.northwestern.edu/5"
         }


### PR DESCRIPTION
I think it's best to use `FileSet` over `File` because of potential confusion with `Elixir.File`. There may be a better name, but I think this fits in with our domain a bit better (Hyrax, PCDM, etc.). You'll have to run `mix ecto.reset` because I modified the migration.